### PR TITLE
Use bytearray and bytearray.join() more consistently

### DIFF
--- a/tests/test_choice.asn1
+++ b/tests/test_choice.asn1
@@ -5,7 +5,8 @@ TestChoice DEFINITIONS ::= BEGIN
   }
 
   Choice1 ::= SEQUENCE {
-      test1 INTEGER (0..255)
+      test1 INTEGER (0..255),
+      str1 OCTET STRING SIZE (0..129)
   }
 
   Choice2 ::= SEQUENCE {

--- a/tests/test_choice.py
+++ b/tests/test_choice.py
@@ -22,7 +22,11 @@ class TestBasic(unittest.TestCase):
     def test_choice1(self):
         test_reload()
         import tests.gen_choice_ber
-        choice1 = tests.gen_choice_ber.Choice1()
+        # Test length > 0x80
+        s = bytearray(0x81)
+        choice1 = tests.gen_choice_ber.Choice1(test1=255, str1=s)
+        choice1.encode()
+        assert(len(choice1.encode()) > 0x80)
 
 
 if __name__ == '__main__':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,6 @@ def generate(infilename, outfilename):
         no_standalone = False
 
     import os
-    print(os.path.realpath(infilename))
-    print(os.path.realpath(outfilename))
     with open(infilename) as f:
         asn1def = f.read()
 

--- a/tinyber/_codec.pyx
+++ b/tinyber/_codec.pyx
@@ -258,7 +258,7 @@ cdef class Encoder:
         while (self.pos + n) > self.size:
             self.grow()
 
-    cdef emit (self, bytes s):
+    cdef emit (self, bytearray s):
         cdef unsigned int slen = len(s)
         cdef unsigned char * pbuf = self.buffer
         cdef unsigned char * ps = s
@@ -337,9 +337,9 @@ cdef class Encoder:
     cpdef emit_BOOLEAN (self, v):
         with self.TLV (TAGS_BOOLEAN):
             if v:
-                self.emit (b'\xff')
+                self.emit_byte (b'\xff')
             else:
-                self.emit (b'\x00')
+                self.emit_byte (b'\x00')
 
 class ASN1:
     value = None

--- a/tinyber/codec.py
+++ b/tinyber/codec.py
@@ -241,7 +241,7 @@ class Encoder:
                 r.insert(0, self._chr(n & 0xff))
                 n >>= 8
             r.insert(0, self._chr(0x80 | len(r)))
-            self.emit(''.join(r))
+            self.emit(bytearray().join(r))
 
     def emit_tag(self, tag, flags=0):
         if tag < 0x1f:
@@ -259,7 +259,7 @@ class Encoder:
         return EncoderContext(self, tag, flags)
 
     def done(self):
-        return b''.join(self.r)
+        return bytearray().join(self.r)
 
     # base types
 
@@ -287,7 +287,7 @@ class Encoder:
                 r.insert(0, self._chr(byte))
                 i += 1
                 n0 = n
-        self.emit(b''.join(r))
+        self.emit(bytearray().join(r))
 
     def emit_INTEGER(self, n):
         with self.TLV(TAG.INTEGER):


### PR DESCRIPTION
This came up when using an object length > 0x80.
